### PR TITLE
Changed Mod ID

### DIFF
--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Animatronics/modinfo.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Animatronics/modinfo.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "MOD_INFO",
-    "id": "Animatronics",
+    "id": "Animatronic_monsters",
     "name": "Animatronic Monsters",
     "authors": [ "Lanceo90" ],
     "description": "Adds a chain of bankrupt pizzerias, with still functioning animatronics inside.",


### PR DESCRIPTION
The game seems to mistake this mod for a similarly named, long outdated mod and remove it from all worlds on startup.
Changing the ID solves the problem.